### PR TITLE
Resolve relative symlinks

### DIFF
--- a/plugin/cscope_dynamic.vim
+++ b/plugin/cscope_dynamic.vim
@@ -208,6 +208,10 @@ function! s:dbUpdate()
             let cmd .= " | grep -v -f".s:small_file.".files "
         endif
 
+        " Trick to resolve links with relative paths
+        "
+        let cmd .= "| xargs realpath --relative-to=$(pwd) "
+
         let cmd .= "> ".s:big_file.".files"
 
         " Build the tags


### PR DESCRIPTION
The Linux kernel code-base can contain relative symlinks like for example:
`include/dt-bindings/input/linux-event-codes.h -> ../../uapi/linux/input-event-codes.h`
Cscope complains about a file not found when it looks for:
`../../uapi/linux/input-event-codes.h`

This patch adds a small pre-processing on the files list generation to ensure that all files are reported using their actual full path.
This avoid cscope complains and it have the additional benefit to get a full patch for each cscope symbol.

Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>