### PR TITLE
fix find invocation (apply "-type" to all searched suffixes)

### DIFF
--- a/plugin/cscope_dynamic.vim
+++ b/plugin/cscope_dynamic.vim
@@ -181,13 +181,14 @@ function! s:dbUpdate()
         let cmd .= "set -f;" " turn off sh globbing
         if s:auto_files
             " Do the find command a 'portable' way
-            let cmd .= "find ".src_dirs." -name *.c   -or -name *.h -or"
+            let cmd .= "find ".src_dirs." -type f -and \\("
+            let cmd .=       " -name *.c   -or -name *.h -or"
             let cmd .=       " -name *.C   -or -name *.H -or"
             let cmd .=       " -name *.c++ -or -name *.h++ -or"
             let cmd .=       " -name *.cxx -or -name *.hxx -or"
             let cmd .=       " -name *.cc  -or -name *.hh -or"
             let cmd .=       " -name *.cpp -or -name *.hpp"
-            let cmd .=       " -type f"
+            let cmd .=       " \\) 2>/dev/null"
         else
             let cmd .= "echo "  " dummy so following cat command does not hang.
         endif


### PR DESCRIPTION
Previous `find` invocation applied `-type f` only to the last name wildcard (part after last -or").

This patch fixes it by using the correct `find` syntax.

Testcase:
```bash
$ mkdir -p  search/dir.c search/dir.h; touch search/file.c search/file.h
$ find search -name \*.c -or -name \*.h -type f
search/dir.c
search/file.h
search/file.c
```
The `search/dir.c` result is invalid.
```bash
$ find search -type f \( -name \*.c -or -name \*.h \)
search/file.h
search/file.c
```

Additionally, the stderr output is redirected to /dev/null to avoid mangling vim screen in case some directories in the search path are not accessible by the user, eg:
```bash
$ chmod 400 search
$ find search -name \*.c -or -name \*.h -type f
find: 'search/dir.c': Permission denied
search/dir.c
find: 'search/dir.h': Permission denied
search/file.h
search/file.c
$ find search -name \*.c -or -name \*.h -type f 2>/dev/null
search/dir.c
search/file.h
search/file.c
```
