### PR TITLE
Prune entries in big_file only if match whole words

### DIFF
--- a/plugin/cscope_dynamic.vim
+++ b/plugin/cscope_dynamic.vim
@@ -206,7 +206,7 @@ function! s:dbUpdate()
         " prune entries that are in the small DB
         "
         if !empty(s:small_file_dict)
-            let cmd .= " | grep -v -f".s:small_file.".files "
+            let cmd .= " | grep -w -v -f".s:small_file.".files "
         endif
 
         " Trick to resolve links with relative paths


### PR DESCRIPTION
Prevent accidentally remove file name due to partial match

[Issue]
Here is the scenario, assume we have _xxx.a_ and _xxx.ah_.
1. Edit and save _xxx.a_. Trigger `smallListUpdate()`. Add _xxx.a_ to `small_file_dict` and small_file
2. `dbUpdate()` calls grep w/o -w option. Cause _xxx.a_ also match _xxx.ah_ and both remove from big_file.
3. _xxx.ah_ will not be able to search anymore.

[Fix]
Add -w option to grep to match only whole words.
